### PR TITLE
Add ability to set `--notimesync` and `--disable hostname` for `domainjoin-cli`.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,3 +27,9 @@ default['pbis-open']['data_bagitem'] = 'credentials'
 default['pbis-open']['ad_domain'] = 'corp.contoso.com'
 default['pbis-open']['options']['LoginShellTemplate'] = '/bin/bash'
 default['pbis-open']['perform_reboot'] = false
+
+# Do not synchronize time with the AD server on domain join.
+default['pbis-open']['join']['time_sync'] = false
+
+# Do not set the underlying node host name on domain join.
+default['pbis-open']['join']['hostname'] = false


### PR DESCRIPTION
This is to stop `domainjoin-cli` from updating underlying node current time and
from changing its host name. See:

  "PBISO Installation and Administration Guide" at
    http://download1.beyondtrust.com/Technical-Support/Downloads/files/PBISO/Manuals/

Signed-off-by: Krzysztof Wilczynski krzysztof.wilczynski@linux.com
